### PR TITLE
Null check handle when source changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -909,7 +909,9 @@ class Manager extends EventEmitter {
       // We ignore notifications for unknown sources.
       for (const queryId of (this._sources.get(payload.name) || [])) {
         const handle = this._getHandleForQuery(queryId);
-        if (handle) handle._onSourceChanged();
+        if (handle) {
+          handle._onSourceChanged();
+        }
       }
     }
     else {

--- a/index.js
+++ b/index.js
@@ -909,7 +909,7 @@ class Manager extends EventEmitter {
       // We ignore notifications for unknown sources.
       for (const queryId of (this._sources.get(payload.name) || [])) {
         const handle = this._getHandleForQuery(queryId);
-        handle._onSourceChanged();
+        if (handle) handle._onSourceChanged();
       }
     }
     else {


### PR DESCRIPTION
I'm sporadically getting some `TypeError: Cannot read property '_onSourceChanged' of undefined` errors.
Not sure what is causing them at the moment, but adding this patch makes them go away.