### PR TITLE
Create FUNDING.yml with Tidelift key/value

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+tidelift: "npm/reactive-postgres"


### PR DESCRIPTION
The FUNDING.yml task is required to unlock the enterprise language. This adds the file but you'll need to go to "Settings" and enable "Sponsorships".